### PR TITLE
Added binding syntax extension method NamedLikeFactoryMethod

### DIFF
--- a/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
@@ -102,6 +102,14 @@ namespace Ninject.Extensions.Factory
         }
 
         [Fact]
+        public void NamedLikeFactoryMethodThrowsExceptionWhenActionIsNull()
+        {
+            Action action = () => this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod<Sword, ICustomizableWeapon>(null);
+            
+            action.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
         public void GetFallback()
         {
             this.kernel.Bind<IWeapon>().To<Dagger>();

--- a/src/Ninject.Extensions.Factory/BindToExtensions.cs
+++ b/src/Ninject.Extensions.Factory/BindToExtensions.cs
@@ -100,6 +100,11 @@ namespace Ninject.Extensions.Factory
         /// </returns>
         public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory>(this IBindingNamedSyntax<TInterface> syntax, Expression<Action<TFactory>> action)
         {
+            if (action == null)
+            {
+                throw new ArgumentNullException("action");
+            }
+
             var methodCallExpression = action.Body as MethodCallExpression;
 
             if (methodCallExpression == null)


### PR DESCRIPTION
added binding syntax extension method for defining a named binding corresponding with a GetXYZ factory method

An extension method to write this:
this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod((IWeaponFactory f) => f.GetSword());
this.kernel.Bind<IWeaponFactory>().ToFactory();

instead of this:
this.kernel.Bind<IWeapon>().To<Sword>().Named("Sword");
this.kernel.Bind<IWeaponFactory>().ToFactory();
