### PR TITLE
add intro blog post url to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,5 @@
 This Ninject extension allows to create factory implementations automatically.
+
+For more information, see the introduction post here:
+
+http://www.planetgeek.ch/2011/12/31/ninject-extensions-factory-introduction/


### PR DESCRIPTION
The current readme doesn't provide much context about the extension, and hopefully including a link to the intro post will help others trying to learn about it.
