### PR TITLE
NamedLikeFactoryMethod updated to work with method arguments

### DIFF
--- a/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
@@ -83,7 +83,24 @@ namespace Ninject.Extensions.Factory
         }
 
         [Fact]
-        public void NamedLikeFactoryMethod()
+        public void NamedLikeFactoryMethodWithArguments()
+        {
+            const string Name = "Excalibur";
+            const int Width = 34;
+            const int Length = 123;
+            
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().NamedLikeFactoryMethod(
+                (IWeaponFactory f, int l, string n, int w) => f.CreateCustomizableWeapon(l, n, w));
+            
+            this.kernel.Bind<IWeaponFactory>().ToFactory();
+
+            var weapon = this.kernel.Get<IWeaponFactory>().CreateCustomizableWeapon(Length, Name,  Width);
+
+            weapon.Should().BeOfType<CustomizableSword>();
+        }
+              
+        [Fact]
+        public void NamedLikeFactoryMethodWithGetPrefix()
         {
             this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod((IWeaponFactory f) => f.GetSword());
             this.kernel.Bind<IWeaponFactory>().ToFactory();
@@ -92,11 +109,22 @@ namespace Ninject.Extensions.Factory
 
             weapon.Should().BeOfType<Sword>();
         }
+      
+        [Fact]
+        public void NamedLikeFactoryMethodWithCreatePrefix()
+        {
+            this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod((IWeaponFactory f) => f.CreateWeapon());
+            this.kernel.Bind<IWeaponFactory>().ToFactory();
 
+            var weapon = this.kernel.Get<IWeaponFactory>().CreateWeapon();
+
+            weapon.Should().BeOfType<Sword>();
+        }     
+        
         [Fact]
         public void NamedLikeFactoryMethodThrowsExceptionWhenNotAGetFactoryMethod()
         {
-            Action action = () => this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod((IWeaponFactory f) => f.CreateWeapon());
+            Action action = () => this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod((IWeaponFactory f) => f.FetchWeapon());
 
             action.ShouldThrow<ArgumentException>();
         }

--- a/src/Ninject.Extensions.Factory.Test/Fakes/IWeaponFactory.cs
+++ b/src/Ninject.Extensions.Factory.Test/Fakes/IWeaponFactory.cs
@@ -25,6 +25,8 @@ namespace Ninject.Extensions.Factory.Fakes
 
     public interface IWeaponFactory
     {
+        IWeapon FetchWeapon();
+        
         IWeapon CreateWeapon();
 
         ICustomizableWeapon CreateCustomizableWeapon(int length, string name, int width);

--- a/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
+++ b/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Ninject.Extensions.Factory.Test</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SignAssembly>false</SignAssembly>
+    <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Ninject.snk</AssemblyOriginatorKeyFile>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -36,11 +36,17 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
+    <NoWin32Manifest>False</NoWin32Manifest>
+    <DelaySign>False</DelaySign>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <NoStdLib>False</NoStdLib>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
     <OutputPath>..\..\build\debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -56,8 +62,19 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <BaseAddress>4194304</BaseAddress>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>False</Prefer32Bit>
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+    <Reference Include="Castle.Core">
       <HintPath>..\..\lib\Castle-DynamicProxy\net-4.0\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions">

--- a/src/Ninject.Extensions.Factory.Test/UnitTests/FactoryInterceptorTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/UnitTests/FactoryInterceptorTests.cs
@@ -48,6 +48,7 @@ namespace Ninject.Extensions.Factory.UnitTests
         public void Intercept()
         {
             var invocation = this.CreateInvocation("TestMethod", 1, "w");
+                      
             this.instanceProviderMock
                 .Setup(ip => ip.GetInstance(this.testee, invocation.Method, invocation.Arguments))
                 .Returns(4);
@@ -64,12 +65,12 @@ namespace Ninject.Extensions.Factory.UnitTests
 
         private IInvocation CreateInvocation(string methodName, params object[] arguments)
         {
-            var invacationMock = new Mock<IInvocation>();
-            invacationMock.Setup(invocation => invocation.Method).Returns(this.GetType().GetMethod(methodName));
-            invacationMock.SetupProperty(invocation => invocation.ReturnValue);
-            invacationMock.Setup(invocation => invocation.Arguments).Returns(arguments);
+            var invocationMock = new Mock<IInvocation>();
+            invocationMock.Setup(invocation => invocation.Method).Returns(this.GetType().GetMethod(methodName));
+            invocationMock.SetupProperty(invocation => invocation.ReturnValue);
+            invocationMock.Setup(invocation => invocation.Arguments).Returns(arguments);
 
-            return invacationMock.Object;
+            return invocationMock.Object;
         }
     }
 }

--- a/src/Ninject.Extensions.Factory/BindToExtensions.cs
+++ b/src/Ninject.Extensions.Factory/BindToExtensions.cs
@@ -2,7 +2,7 @@
 // <copyright file="BindToExtensions.cs" company="Ninject Project Contributors">
 //   Copyright (c) 2009-2011 Ninject Project Contributors
 //   Authors: Remo Gloor (remo.gloor@gmail.com)
-//           
+//
 //   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
 //   you may not use this file except in compliance with one of the Licenses.
 //   You may obtain a copy of the License at
@@ -23,6 +23,7 @@
 namespace Ninject.Extensions.Factory
 {
     using System;
+    using System.Dynamic;
     using System.Linq.Expressions;
 
     using Castle.DynamicProxy;
@@ -100,8 +101,278 @@ namespace Ninject.Extensions.Factory
         /// <returns>
         /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
         /// </returns>
-        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory>(this IBindingNamedSyntax<TInterface> syntax, Expression<Action<TFactory>> action)
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory>> action)
         {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2>> action)
+        {            
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(
+            this IBindingNamedSyntax<TInterface> syntax,
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>> action)
+        {
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <typeparam name="TFactory">¨The type of the factory.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethod<TInterface, TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(
+            this IBindingNamedSyntax<TInterface> syntax, 
+            Expression<Action<TFactory, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>> action)
+        {                      
+            return NamedLikeFactoryMethodDynamic(syntax, action);
+        }             
+        
+        /// <summary>
+        /// Defines a named binding with the name taken from the factory method used to create instances.
+        /// </summary>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="action">Expression defining the factory method used to get the binding name from.</param>
+        /// <returns0>
+        /// The <see cref="IBindingWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        private static IBindingWithOrOnSyntax<TInterface> NamedLikeFactoryMethodDynamic<TInterface>(IBindingNamedSyntax<TInterface> syntax, dynamic action)
+        {       
             if (action == null)
             {
                 throw new ArgumentNullException("action");
@@ -109,22 +380,21 @@ namespace Ninject.Extensions.Factory
 
             var methodCallExpression = action.Body as MethodCallExpression;
 
-            if (methodCallExpression == null)
+            if (methodCallExpression == null) 
             {
                 throw new ArgumentException("expected factory method instead of " + action, "action");
             }
-
+            
             var methodName = methodCallExpression.Method.Name;
-
-            if (!methodName.StartsWith("Get"))
+            
+            if (!methodName.StartsWith("Get") && !methodName.StartsWith("Create")) 
             {
-                throw new ArgumentException("expected factory 'Get' method instead of " + action, "action");
+                throw new ArgumentException("expected factory 'Get' or 'Create' method instead of " + action, "action");
             }
-
-            var bindingName = methodName.Substring(3);
-
+            
+            var bindingName = methodName.StartsWith("Get") ? methodName.Substring(3) : methodName.Substring(6);
             return syntax.Named(bindingName);
-        }
+        }       
 
         /// <summary>
         /// Defines that the interface shall be bound to an automatically created factory proxy.
@@ -136,7 +406,7 @@ namespace Ninject.Extensions.Factory
         /// <returns>
         /// The <see cref="IBindingWhenInNamedWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
         /// </returns>
-        private static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInterface>(IBindingToSyntax<TInterface> syntax, Func<IContext, IInstanceProvider> instanceProvider, Type factoryType) 
+        private static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInterface>(IBindingToSyntax<TInterface> syntax, Func<IContext, IInstanceProvider> instanceProvider, Type factoryType)
             where TInterface : class
         {
             var proxy = Generator.ProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(

--- a/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
+++ b/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
@@ -35,17 +35,21 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <NoWin32Manifest>False</NoWin32Manifest>
+    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <NoStdLib>False</NoStdLib>
+    <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
     <OutputPath>..\..\build\debug\</OutputPath>
     <DefineConstants>TRACE;DEBUG;NO_PARTIAL_TRUST</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <DocumentationFile>
-    </DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -58,10 +62,23 @@
     <DocumentationFile>..\..\build\release\Ninject.Extensions.Factory.XML</DocumentationFile>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <CheckForOverflowUnderflow>False</CheckForOverflowUnderflow>
+    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+    <StartAction>Project</StartAction>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
+    <BaseAddress>4194304</BaseAddress>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Prefer32Bit>False</Prefer32Bit>
+    <RegisterForComInterop>False</RegisterForComInterop>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core">
       <HintPath>..\..\lib\Castle-DynamicProxy\net-4.0\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Ninject, Version=3.0.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
       <HintPath>..\..\lib\Ninject\net-4.0\Ninject.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -70,6 +87,7 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.Dynamic" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
NamedLikeFactoryMethod now works with factory methods that have parameters and method names that start with 'Create' (not just 'Get').
