### PR TITLE
Adding decorator support

### DIFF
--- a/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
@@ -305,6 +305,42 @@ namespace Ninject.Extensions.Factory
             handlers.Single().Should().BeOfType<IntMessageHandler>();
         }
 
+        [Fact]
+        public void DecoratorShouldBeInjectedWithAppropriateBinding()
+        {
+            this.kernel.Bind<IWeapon>().To<DecoratedWeapon>();
+            this.kernel.Bind<IWeapon>().To<Sword>().WhenInjectedExactlyInto<DecoratedWeapon>();
+            this.kernel.Bind<IWeaponFactory>().ToFactory();
+
+            var instance = this.kernel.Get<IWeaponFactory>().CreateWeapon();
+            var decoratedWeapon = instance as DecoratedWeapon;
+
+            instance.Should().BeOfType<DecoratedWeapon>();
+            decoratedWeapon.WeaponToBeDecorated.Should().BeOfType<Sword>();
+
+        }
+
+        [Fact]
+        public void DecoratorShouldBeInjectedWithAppropriateBindingWithArguments()
+        {
+            const string Name = "Excalibur";
+            const int Width = 34;
+            const int Length = 123;
+
+            this.kernel.Bind<ICustomizableWeapon>().To<DecoratedCustomizableWeapon>();
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().WhenInjectedExactlyInto<DecoratedCustomizableWeapon>();
+            this.kernel.Bind<IWeaponFactory>().ToFactory();
+
+            var weapon = this.kernel.Get<IWeaponFactory>().CreateCustomizableWeapon(Length, Name, Width);
+            var decoratedWeapon = weapon as DecoratedCustomizableWeapon;
+
+            weapon.Should().BeOfType<DecoratedCustomizableWeapon>();
+            decoratedWeapon.WeaponToBeDecorated.Should().BeOfType<CustomizableSword>();
+            weapon.Name.Should().Be(Name);
+            weapon.Length.Should().Be(Length);
+            weapon.Width.Should().Be(Width);
+        }
+
         private class CustomInstanceProvider : StandardInstanceProvider
         {
             protected override string GetName(System.Reflection.MethodInfo methodInfo, object[] arguments)

--- a/src/Ninject.Extensions.Factory.Test/Fakes/DecoratedCustomizableWeapon.cs
+++ b/src/Ninject.Extensions.Factory.Test/Fakes/DecoratedCustomizableWeapon.cs
@@ -1,0 +1,48 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="Sword.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Remo Gloor (remo.gloor@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Ninject.Extensions.Factory.Fakes
+{
+    public class DecoratedCustomizableWeapon : ICustomizableWeapon
+    {
+        public ICustomizableWeapon WeaponToBeDecorated { get; private set; }
+
+        public DecoratedCustomizableWeapon(ICustomizableWeapon weaponToBeDecorated)
+        {
+            WeaponToBeDecorated = weaponToBeDecorated;
+        }
+
+        public string Name
+        {
+            get { return WeaponToBeDecorated.Name; }
+        }
+
+        public int Width
+        {
+            get { return WeaponToBeDecorated.Width; }
+        }
+
+        public int Length
+        {
+            get { return WeaponToBeDecorated.Length; }
+        }
+    }
+}

--- a/src/Ninject.Extensions.Factory.Test/Fakes/DecoratedWeapon.cs
+++ b/src/Ninject.Extensions.Factory.Test/Fakes/DecoratedWeapon.cs
@@ -1,0 +1,38 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="Sword.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Remo Gloor (remo.gloor@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Ninject.Extensions.Factory.Fakes
+{
+    public class DecoratedWeapon : IWeapon
+    {
+        public IWeapon WeaponToBeDecorated { get; private set; }
+
+        public DecoratedWeapon(IWeapon weaponToBeDecorated)
+        {
+            WeaponToBeDecorated = weaponToBeDecorated;
+        }
+
+        public string Name
+        {
+            get { return "decorated " + WeaponToBeDecorated.Name; }
+        }
+    }
+}

--- a/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
+++ b/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
@@ -95,6 +95,8 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Fakes\Barrack.cs" />
+    <Compile Include="Fakes\DecoratedCustomizableWeapon.cs" />
+    <Compile Include="Fakes\DecoratedWeapon.cs" />
     <Compile Include="Fakes\IBarrackFactory.cs" />
     <Compile Include="Fakes\ClassWithCollectionFunc.cs" />
     <Compile Include="Fakes\ClassWithLazy.cs" />

--- a/src/Ninject.Extensions.Factory/Factory/StandardInstanceProvider.cs
+++ b/src/Ninject.Extensions.Factory/Factory/StandardInstanceProvider.cs
@@ -125,7 +125,7 @@ namespace Ninject.Extensions.Factory
             var constructorArguments = new ConstructorArgument[parameters.Length];
             for (int i = 0; i < parameters.Length; i++)
             {
-                constructorArguments[i] = new ConstructorArgument(parameters[i].Name, arguments[i]);
+                constructorArguments[i] = new ConstructorArgument(parameters[i].Name, arguments[i], true);
             }
 
             return constructorArguments;


### PR DESCRIPTION
When using the decorator pattern the object that is being decorated should be injected into the decorator. When the factory sends the constructor parameters it should use them to create the object that is being decorated, not the decorator.  
