### PR TITLE
Handle generic Lazy parameters correctly in LazyConstructorScorer

### DIFF
--- a/src/Ninject.Extensions.Factory.Test/Fakes/ClassWithGenericLazy.cs
+++ b/src/Ninject.Extensions.Factory.Test/Fakes/ClassWithGenericLazy.cs
@@ -1,0 +1,41 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ClassWithGenericLazy.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2018 Ninject Project Contributors
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   You may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+#if !NET_35 && !SILVERLIGHT_30 && !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
+namespace Ninject.Extensions.Factory.Fakes
+{
+    using System;
+
+    public class ClassWithGenericLazy
+    {
+        private readonly Lazy<Lazy<IWeapon>> lazyWeapons;
+
+        public ClassWithGenericLazy(Lazy<Lazy<IWeapon>> lazyWeapons)
+        {
+            this.lazyWeapons = lazyWeapons;
+        }
+
+        public IWeapon GetWeapon()
+        {
+            return this.lazyWeapons.Value.Value;
+        }
+    }
+}
+#endif

--- a/src/Ninject.Extensions.Factory.Test/FuncTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/FuncTests.cs
@@ -201,6 +201,20 @@ namespace Ninject.Extensions.Factory
             weapon2.Should().BeOfType<Sword>();
             weapon1.Should().BeSameAs(weapon2);
         }
+
+        [Fact]
+        public void GenericLazyInjection()
+        {
+            this.kernel.Bind<IWeapon>().To<Sword>();
+
+            var service = this.kernel.Get<ClassWithGenericLazy>();
+            var weapon1 = service.GetWeapon();
+            var weapon2 = service.GetWeapon();
+
+            weapon1.Should().BeOfType<Sword>();
+            weapon2.Should().BeOfType<Sword>();
+            weapon1.Should().BeSameAs(weapon2);
+        }
 #endif
 
         [Theory]

--- a/src/Ninject.Extensions.Factory/Func/LazyConstructorScorer.cs
+++ b/src/Ninject.Extensions.Factory/Func/LazyConstructorScorer.cs
@@ -46,12 +46,30 @@ namespace Ninject.Extensions.Factory
                 if (directive.Constructor.GetParameters().Length == 1 &&
                     directive.Constructor.GetParameters()[0].ParameterType.IsGenericType)
                 {
-                    return 1;
+                    var parameterGenericType = directive.Constructor.GetParameters()[0].ParameterType.GetGenericTypeDefinition();
+                    if (parameterGenericType == typeof(Func<>)
+                        || parameterGenericType == typeof(Func<,>)
+                        || parameterGenericType == typeof(Func<,,>)
+                        || parameterGenericType == typeof(Func<,,,>)
+                        || parameterGenericType == typeof(Func<,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,,,,,>)
+                        || parameterGenericType == typeof(Func<,,,,,,,,,,,,,,,,>))
+                    {
+                        return 1;
+                    }
                 }
-                else
-                {
-                    return 0;
-                }
+
+                return 0;
             }
             else
             {


### PR DESCRIPTION
Fix for an issue related to #38. The solution introduced related to that issue does solve it when the T in `Lazy<T>` itself is not generic. However when T is generic there will still be two constructors with the same score.
This change fixes this issue by explicitly looking for the constructor with the only Func parameter
