### PR TITLE
Added ToFactory extension methods for IInstanceProvider activation

### DIFF
--- a/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
+++ b/src/Ninject.Extensions.Factory.Test/FactoryTests.cs
@@ -42,13 +42,13 @@ namespace Ninject.Extensions.Factory
         {
             this.kernel.Dispose();
         }
- 
+
         [Fact]
         public void SingleBinding()
         {
             this.kernel.Bind<IWeapon>().To<Sword>();
             this.kernel.Bind<IWeaponFactory>().ToFactory();
-            
+
             var weapon = this.kernel.Get<IWeaponFactory>().CreateWeapon();
 
             weapon.Should().BeOfType<Sword>();
@@ -64,14 +64,14 @@ namespace Ninject.Extensions.Factory
 
             weapon.Should().BeOfType<Sword>();
         }
-        
+
         [Fact]
         public void NamedBinding()
         {
             this.kernel.Bind<IWeapon>().To<Sword>().Named("Sword");
             this.kernel.Bind<IWeapon>().To<Dagger>().Named("Dagger");
             this.kernel.Bind<IWeaponFactory>().ToFactory();
-            
+
             var weapon = this.kernel.Get<IWeaponFactory>().GetSword();
 
             weapon.Should().BeOfType<Sword>();
@@ -100,7 +100,7 @@ namespace Ninject.Extensions.Factory
         public void NamedLikeFactoryMethodThrowsExceptionWhenActionIsNull()
         {
             Action action = () => this.kernel.Bind<IWeapon>().To<Sword>().NamedLikeFactoryMethod<Sword, ICustomizableWeapon>(null);
-            
+
             action.ShouldThrow<ArgumentNullException>();
         }
 
@@ -127,14 +127,14 @@ namespace Ninject.Extensions.Factory
 
             weapon.Should().BeOfType<Sword>();
         }
-        
+
         [Fact]
         public void GetEnumerable()
         {
             this.kernel.Bind<IWeapon>().To<Sword>();
             this.kernel.Bind<IWeapon>().To<Dagger>();
             this.kernel.Bind<IWeaponFactory>().ToFactory();
-            
+
             var weapons = this.kernel.Get<IWeaponFactory>().CreateAllWeaponsEnumerable();
 
             weapons.Should().HaveCount(2);
@@ -197,7 +197,7 @@ namespace Ninject.Extensions.Factory
             weapons.OfType<Sword>().Should().HaveCount(1);
             weapons.OfType<Dagger>().Should().HaveCount(1);
         }
-        
+
         [Fact]
         public void BindToFactoryWithArguments()
         {
@@ -270,7 +270,87 @@ namespace Ninject.Extensions.Factory
             instance.Length.Should().Be(Length);
             instance.Width.Should().Be(Width);
         }
-        
+
+        [Fact]
+        public void CustomInstanceProviderWhenUsingIContextAndNoneGenericBindTest()
+        {
+            const string Name = "theName";
+            const int Length = 1;
+            const int Width = 2;
+
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().Named("sword");
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableDagger>().Named("dagger");
+            this.kernel.Bind(typeof(ISpecialWeaponFactory)).ToFactory(ctx => ctx.Kernel.Get<CustomInstanceProvider>(), typeof(ISpecialWeaponFactory));
+
+            var factory = this.kernel.Get<ISpecialWeaponFactory>();
+            var instance = factory.CreateWeapon("sword", Length, Name, Width);
+
+            instance.Should().BeOfType<CustomizableSword>();
+            instance.Name.Should().Be(Name);
+            instance.Length.Should().Be(Length);
+            instance.Width.Should().Be(Width);
+        }
+
+        [Fact]
+        public void CustomInstanceProviderWhenUsingGenericInstanceProviderAndNoneGenericBindTest()
+        {
+            const string Name = "theName";
+            const int Length = 1;
+            const int Width = 2;
+
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().Named("sword");
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableDagger>().Named("dagger");
+            this.kernel.Bind(typeof(ISpecialWeaponFactory)).ToFactory<CustomInstanceProvider>(typeof(ISpecialWeaponFactory));
+
+            var factory = this.kernel.Get<ISpecialWeaponFactory>();
+            var instance = factory.CreateWeapon("sword", Length, Name, Width);
+
+            instance.Should().BeOfType<CustomizableSword>();
+            instance.Name.Should().Be(Name);
+            instance.Length.Should().Be(Length);
+            instance.Width.Should().Be(Width);
+        }
+
+        [Fact]
+        public void CustomInstanceProviderWhenUsingGenericInstanceProviderBindTest()
+        {
+            const string Name = "theName";
+            const int Length = 1;
+            const int Width = 2;
+
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().Named("sword");
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableDagger>().Named("dagger");
+            this.kernel.Bind<ISpecialWeaponFactory>().ToFactory<CustomInstanceProvider, ISpecialWeaponFactory>();
+
+            var factory = this.kernel.Get<ISpecialWeaponFactory>();
+            var instance = factory.CreateWeapon("sword", Length, Name, Width);
+
+            instance.Should().BeOfType<CustomizableSword>();
+            instance.Name.Should().Be(Name);
+            instance.Length.Should().Be(Length);
+            instance.Width.Should().Be(Width);
+        }
+
+        [Fact]
+        public void CustomInstanceProviderWhenUsingIContextTest()
+        {
+            const string Name = "theName";
+            const int Length = 1;
+            const int Width = 2;
+
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableSword>().Named("sword");
+            this.kernel.Bind<ICustomizableWeapon>().To<CustomizableDagger>().Named("dagger");
+            this.kernel.Bind<ISpecialWeaponFactory>().ToFactory(ctx => ctx.Kernel.Get<CustomInstanceProvider>());
+
+            var factory = this.kernel.Get<ISpecialWeaponFactory>();
+            var instance = factory.CreateWeapon("sword", Length, Name, Width);
+
+            instance.Should().BeOfType<CustomizableSword>();
+            instance.Name.Should().Be(Name);
+            instance.Length.Should().Be(Length);
+            instance.Width.Should().Be(Width);
+        }
+
         [Fact]
         public void DefaultAndCustomInstanceProviderCanBeMixed()
         {

--- a/src/Ninject.Extensions.Factory/BindToExtensions.cs
+++ b/src/Ninject.Extensions.Factory/BindToExtensions.cs
@@ -49,6 +49,21 @@ namespace Ninject.Extensions.Factory
         /// <summary>
         /// Defines that the interface shall be bound to an automatically created factory proxy.
         /// </summary>
+        /// <typeparam name="TInstanceProvider">The type of instance provider.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="factoryType">The type of the factory.</param>
+        /// <returns>
+        /// The <see cref="IBindingWhenInNamedWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWhenInNamedWithOrOnSyntax<object> ToFactory<TInstanceProvider>(this IBindingToSyntax<object> syntax, Type factoryType)
+            where TInstanceProvider : IInstanceProvider
+        {
+            return ToFactory(syntax, ctx => ctx.Kernel.Get<TInstanceProvider>(), factoryType);
+        }
+
+        /// <summary>
+        /// Defines that the interface shall be bound to an automatically created factory proxy.
+        /// </summary>
         /// <param name="syntax">The syntax.</param>
         /// <param name="factoryType">The type of the factory.</param>
         /// <returns>
@@ -72,6 +87,22 @@ namespace Ninject.Extensions.Factory
             where TInterface : class
         {
             return ToFactory(syntax, ctx => instanceProvider(), typeof(TInterface));
+        }
+
+        /// <summary>
+        /// Defines that the interface shall be bound to an automatically created factory proxy.
+        /// </summary>
+        /// <typeparam name="TInstanceProvider">The type of instance provider.</typeparam>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <returns>
+        /// The <see cref="IBindingWhenInNamedWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInstanceProvider, TInterface>(this IBindingToSyntax<TInterface> syntax)
+            where TInterface : class
+            where TInstanceProvider : IInstanceProvider
+        {
+            return ToFactory(syntax, ctx => ctx.Kernel.Get<TInstanceProvider>(), typeof(TInterface));
         }
 
         /// <summary>
@@ -166,11 +197,26 @@ namespace Ninject.Extensions.Factory
         /// <typeparam name="TInterface">The type of the interface.</typeparam>
         /// <param name="syntax">The syntax.</param>
         /// <param name="instanceProvider">The instance provider.</param>
+        /// <returns>
+        /// The <see cref="IBindingWhenInNamedWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
+        /// </returns>
+        public static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInterface>(this IBindingToSyntax<TInterface> syntax, Func<IContext, IInstanceProvider> instanceProvider)
+            where TInterface : class
+        {
+            return ToFactory(syntax, instanceProvider, typeof(TInterface));
+        }
+
+        /// <summary>
+        /// Defines that the interface shall be bound to an automatically created factory proxy.
+        /// </summary>
+        /// <typeparam name="TInterface">The type of the interface.</typeparam>
+        /// <param name="syntax">The syntax.</param>
+        /// <param name="instanceProvider">The instance provider.</param>
         /// <param name="factoryType">Type of the factory.</param>
         /// <returns>
         /// The <see cref="IBindingWhenInNamedWithOrOnSyntax{TInterface}"/> to configure more things for the binding.
         /// </returns>
-        private static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInterface>(IBindingToSyntax<TInterface> syntax, Func<IContext, IInstanceProvider> instanceProvider, Type factoryType)
+        public static IBindingWhenInNamedWithOrOnSyntax<TInterface> ToFactory<TInterface>(this IBindingToSyntax<TInterface> syntax, Func<IContext, IInstanceProvider> instanceProvider, Type factoryType)
             where TInterface : class
         {
             var proxy = Generator.ProxyBuilder.CreateInterfaceProxyTypeWithoutTarget(


### PR DESCRIPTION
Adds three ToFactory extension method overloads to allow using the kernel to retrieve the correct IInstanceProvider. This will allow standard Ninject activation of the IInstanceProvider. Following are new bindings that are now possible and have been added to unit tests:
```csharp
this.kernel.Bind<ISpecialWeaponFactory>().ToFactory<CustomInstanceProvider, ISpecialWeaponFactory>();

this.kernel.Bind(typeof(ISpecialWeaponFactory)).ToFactory<CustomInstanceProvider>(typeof(ISpecialWeaponFactory));

this.kernel.Bind<ISpecialWeaponFactory>().ToFactory(ctx => ctx.Kernel.Get<CustomInstanceProvider>());
```

Also updates existing private ToFactory method to a public extension method. This specifically allows non-generic binding using IContext to retrieve the IInstanceProvider:
```csharp
this.kernel.Bind(typeof(ISpecialWeaponFactory)).ToFactory(ctx => ctx.Kernel.Get<CustomInstanceProvider>(), typeof(ISpecialWeaponFactory));
```