### PR TITLE
Updated Castle.Core to latest and .NET Framework to 4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Updated Castle.Core to 5.2.1
+- Updated .NET Framework target to 4.6.2
+
 ## [3.3.3] - 2020-08-30
 
 ### Fixed

--- a/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
+++ b/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.0" />
+    <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.7.137" />

--- a/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
+++ b/src/Ninject.Extensions.Factory.Test/Ninject.Extensions.Factory.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
+++ b/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.0" />
+    <PackageReference Include="Castle.Core" Version="5.2.1" />
     <PackageReference Include="Ninject" Version="3.3.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>All</PrivateAssets>

--- a/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
+++ b/src/Ninject.Extensions.Factory/Ninject.Extensions.Factory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <Authors>Ninject Project Contributors</Authors>
     <Company>Ninject Project Contributors</Company>
     <Product>Factory extension for Ninject</Product>


### PR DESCRIPTION
Updated Castle.Core to the latest version which gets rid of some vulnerabilities in the dependency tree (CVE-2018-8292, CVE-2019-0820) and this should also fix #53.
As a consequence the .NET Framework had to be increased to v4.6.2.

It would be great if we could get a new release on nuget.org with this change.